### PR TITLE
SDT-1126

### DIFF
--- a/SW-sdk-45/Helpers/XmlUtils.cs
+++ b/SW-sdk-45/Helpers/XmlUtils.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace SW.Helpers
+{
+    public static class XmlUtils
+    {
+        public static string AddAddenda(string cfdiOriginal, string cfdiStamped,bool isb64)
+        {
+            string cfdi = cfdiStamped;
+            try
+            {
+                cfdiOriginal = isb64 ? Encoding.UTF8.GetString(Convert.FromBase64String(cfdiOriginal)) : cfdiOriginal;
+                XmlDocument xmlDocument = new XmlDocument();
+                xmlDocument.LoadXml(cfdiOriginal);
+                XmlNode addenda = null;
+                var elements = xmlDocument.GetElementsByTagName("cfdi:Addenda");
+                if (elements != null && elements.Count > 0)
+                {
+                    addenda = elements[0];
+                    if (addenda != null)
+
+                        if (addenda != null && addenda.HasChildNodes)
+                        {
+                            XmlDocument xmlDocumentStamped = new XmlDocument();
+                            xmlDocumentStamped.LoadXml(cfdiStamped);
+                            var addendaEl = xmlDocumentStamped.CreateElement(addenda.Prefix, addenda.LocalName, addenda.NamespaceURI);
+                            addendaEl.InnerXml = addenda.InnerXml;
+                            xmlDocumentStamped.DocumentElement.AppendChild(addendaEl);
+                            cfdi = xmlDocumentStamped.OuterXml;
+                        }
+                }
+            }
+            catch (Exception)
+            {
+                //TODO: Report Error
+            }
+            return cfdi;
+        }
+    }
+}

--- a/SW-sdk-45/Properties/AssemblyInfo.cs
+++ b/SW-sdk-45/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.7.1")]
-[assembly: AssemblyFileVersion("0.0.7.1")]
+[assembly: AssemblyVersion("0.0.7.2")]
+[assembly: AssemblyFileVersion("0.0.7.2")]

--- a/SW-sdk-45/SW-sdk-45.csproj
+++ b/SW-sdk-45/SW-sdk-45.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Helpers\ResponseType.cs" />
     <Compile Include="Helpers\StreamUtil.cs" />
     <Compile Include="Helpers\Validation.cs" />
+    <Compile Include="Helpers\XmlUtils.cs" />
     <Compile Include="Services\AcceptReject\AcceptReject.cs" />
     <Compile Include="Services\AcceptReject\AcceptRejectRequestCSD.cs" />
     <Compile Include="Services\AcceptReject\AcceptRejectRequestPFX.cs" />

--- a/SW-sdk-45/Services/ResponseHandler.cs
+++ b/SW-sdk-45/Services/ResponseHandler.cs
@@ -1,4 +1,5 @@
 ﻿using SW.Entities;
+using SW.Helpers;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -12,6 +13,12 @@ namespace SW.Services
     internal abstract class ResponseHandler<T>
         where T : Response, new()
     {
+        public ResponseHandler() { }
+        public readonly string _xmlOriginal;
+        public ResponseHandler(string xmlOriginal)
+        {
+            _xmlOriginal = xmlOriginal;
+        }
         public virtual T GetPostResponse(string url, string path, Dictionary<string, string> headers, HttpContent content, HttpClientHandler proxy)
         {
             try
@@ -89,7 +96,7 @@ namespace SW.Services
             }
         }
         public abstract T HandleException(Exception ex);
-        private T TryGetResponse(HttpResponseMessage response)
+        internal virtual T TryGetResponse(HttpResponseMessage response)
         {
             try
             {
@@ -115,6 +122,50 @@ namespace SW.Services
                 };
             }
         }
-
+        internal virtual string GetCfdiData(Response response, string cfdi, bool isb64)
+        {
+            try
+            {
+               
+                return XmlUtils.AddAddenda(_xmlOriginal, cfdi, isb64);
+                
+            }
+            catch (Exception)
+            {
+            }
+            return cfdi;
+        }
+        internal virtual bool Has307AndAddenda(Response response, Stamp.Data_CFDI data)
+        {
+            try
+            {
+                if (response.status == "error" &&
+               (response.message != null && response.message.Trim().ToLower().Replace(".", "").Contains("307 el comprobante contiene un timbre previo"))
+               && (data != null && !string.IsNullOrEmpty(data.cfdi)))
+                {
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+            }
+            return false;
+        }
+        internal virtual bool Has307AndAddenda(Response response, Stamp.Data_CFDI_TFD data)
+        {
+            try
+            {
+                if (response.status == "error" &&
+               (response.message != null && response.message.Trim().ToLower().Replace(".", "").Contains("307 el comprobante contiene un timbre previo"))
+               && (data != null && !string.IsNullOrEmpty(data.cfdi)))
+                {
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+            }
+            return false;
+        }
     }
 }

--- a/SW-sdk-45/Services/Stamp/BaseStampV2.cs
+++ b/SW-sdk-45/Services/Stamp/BaseStampV2.cs
@@ -41,7 +41,7 @@ namespace SW.Services.Stamp
         }
         public virtual StampResponseV2 TimbrarV2(string xml, bool isb64 = false)
         {
-            StampResponseHandlerV2 handler = new StampResponseHandlerV2();
+            StampResponseHandlerV2 handler = new StampResponseHandlerV2(xml);
             try
             {
                 string format = isb64 ? "b64" : "";
@@ -62,7 +62,7 @@ namespace SW.Services.Stamp
         }
         public virtual StampResponseV3 TimbrarV3(string xml, bool isb64 = false)
         {
-            StampResponseHandlerV3 handler = new StampResponseHandlerV3();
+            StampResponseHandlerV3 handler = new StampResponseHandlerV3(xml);
             try
             {
                 string format = isb64 ? "b64" : "";
@@ -83,7 +83,7 @@ namespace SW.Services.Stamp
         }
         public virtual StampResponseV4 TimbrarV4(string xml, bool isb64 = false)
         {
-            StampResponseHandlerV4 handler = new StampResponseHandlerV4();
+            StampResponseHandlerV4 handler = new StampResponseHandlerV4(xml);
             try
             {
                 string format = isb64 ? "b64" : "";

--- a/SW-sdk-45/Services/Stamp/StampResponseHandler.cs
+++ b/SW-sdk-45/Services/Stamp/StampResponseHandler.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
+using System.Xml;
 using SW.Helpers;
 
 namespace SW.Services.Stamp
@@ -16,6 +18,22 @@ namespace SW.Services.Stamp
     }
     internal class StampResponseHandlerV2 : ResponseHandler<StampResponseV2>
     {
+        public StampResponseHandlerV2()
+        {
+        }
+
+        public StampResponseHandlerV2(string xmlOriginal) : base(xmlOriginal)
+        {
+        }
+
+        public override StampResponseV2 GetPostResponse(string url, string path, Dictionary<string, string> headers, HttpContent content, HttpClientHandler proxy)
+        {
+            var response = base.GetPostResponse(url, path, headers, content, proxy);
+            if (base.Has307AndAddenda(response, response.data))
+                response.data.cfdi = base.GetCfdiData(response, response.data.cfdi, path.ToLower().EndsWith("b64"));
+            return response;
+        }
+
         public override StampResponseV2 HandleException(Exception ex)
         {
             return ex.ToStampResponseV2();
@@ -23,6 +41,21 @@ namespace SW.Services.Stamp
     }
     internal class StampResponseHandlerV3 : ResponseHandler<StampResponseV3>
     {
+        public StampResponseHandlerV3()
+        {
+        }
+
+        public StampResponseHandlerV3(string xmlOriginal) : base(xmlOriginal)
+        {
+        }
+
+        public override StampResponseV3 GetPostResponse(string url, string path, Dictionary<string, string> headers, HttpContent content, HttpClientHandler proxy)
+        {
+            var response = base.GetPostResponse(url, path, headers, content, proxy);
+            if (base.Has307AndAddenda(response, response.data))
+                response.data.cfdi = base.GetCfdiData(response, response.data.cfdi, path.ToLower().EndsWith("b64"));
+            return response;
+        }
         public override StampResponseV3 HandleException(Exception ex)
         {
             return ex.ToStampResponseV3();
@@ -30,6 +63,21 @@ namespace SW.Services.Stamp
     }
     internal class StampResponseHandlerV4 : ResponseHandler<StampResponseV4>
     {
+        public override StampResponseV4 GetPostResponse(string url, string path, Dictionary<string, string> headers, HttpContent content, HttpClientHandler proxy)
+        {
+            var response = base.GetPostResponse(url, path, headers, content, proxy);
+            if (base.Has307AndAddenda(response, response.data))
+                response.data.cfdi = base.GetCfdiData(response, response.data.cfdi, path.ToLower().EndsWith("b64"));
+            return response;
+        }
+        public StampResponseHandlerV4()
+        {
+        }
+
+        public StampResponseHandlerV4(string xmlOriginal) : base(xmlOriginal)
+        {
+        }
+
         public override StampResponseV4 HandleException(Exception ex)
         {
             return ex.ToStampResponseV4();

--- a/Test_SW-sdk-45/Resources/file.xml
+++ b/Test_SW-sdk-45/Resources/file.xml
@@ -18,4 +18,11 @@
       <cfdi:Traslado Importe="371.20" Impuesto="003" TasaOCuota="1.600000" TipoFactor="Tasa"/>
     </cfdi:Traslados>
   </cfdi:Impuestos>
+  <cfdi:Addenda>
+    <smarterweb>
+      <empresa>Luna Soft SA De CV</empresa>
+      <servicios>Timbrado</servicios>
+      <certificaciones>ISO27001</certificaciones>
+    </smarterweb>
+  </cfdi:Addenda>
 </cfdi:Comprobante>

--- a/Test_SW-sdk-45/Services/Relations/Relations_Test.cs
+++ b/Test_SW-sdk-45/Services/Relations/Relations_Test.cs
@@ -24,7 +24,7 @@ namespace Test_SW.Services.Relations_Test
         {
             var build = new BuildSettings();
             Relations relations = new Relations(build.Url, build.User, build.Password);
-            RelationsResponse response = relations.RelationsByRfcUuid(build.Rfc, "01724196-ac5a-4735-b621-e3b42bcbb459");
+            RelationsResponse response = relations.RelationsByRfcUuid(build.Rfc, "31c885c8-6dcb-4d82-9cfd-01707c828c50");
             Assert.IsTrue(response.status == "success");
         }
         [TestMethod]
@@ -32,7 +32,7 @@ namespace Test_SW.Services.Relations_Test
         {
             var build = new BuildSettings();
             Relations relations = new Relations(build.Url, build.User, build.Password);
-            RelationsResponse response = relations.RelationsByCSD(build.Cer, build.Key, build.Rfc, build.CerPassword, "01724196-ac5a-4735-b621-e3b42bcbb459");
+            RelationsResponse response = relations.RelationsByCSD(build.Cer, build.Key, build.Rfc, build.CerPassword, "31c885c8-6dcb-4d82-9cfd-01707c828c50");
             Assert.IsTrue(response.status == "success");
         }
         [TestMethod]
@@ -40,7 +40,7 @@ namespace Test_SW.Services.Relations_Test
         {
             var build = new BuildSettings();
             Relations relations = new Relations(build.Url, build.User, build.Password);
-            RelationsResponse response = relations.RelationsByPFX(build.Pfx, build.Rfc, build.CerPassword, "01724196-ac5a-4735-b621-e3b42bcbb459");
+            RelationsResponse response = relations.RelationsByPFX(build.Pfx, build.Rfc, build.CerPassword, "31c885c8-6dcb-4d82-9cfd-01707c828c50");
             Assert.IsTrue(response.status == "success");
         }
         [TestMethod]

--- a/Test_SW-sdk-45/Services/Stamp/StampV2_Test.cs
+++ b/Test_SW-sdk-45/Services/Stamp/StampV2_Test.cs
@@ -38,7 +38,20 @@ namespace Test_SW.Services.Stamp_Test
             response = (StampResponseV2)stamp.TimbrarV2(xml);
             Assert.IsTrue(response.status == "error" && response.message == "307. El comprobante contiene un timbre previo.");
         }
-        
+        [TestMethod]
+        public void Stamp_Test_45_StampV2XMLV2WithAddenda307()
+        {
+            var build = new BuildSettings();
+            StampV2 stamp = new StampV2(build.Url, build.User, build.Password);
+            var xml = GetXml(build);
+            var response = (StampResponseV2)stamp.TimbrarV2(xml);
+            Assert.IsTrue(response.status == "success"
+               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.tfd viene vacio.");
+            response = (StampResponseV2)stamp.TimbrarV2(xml);
+            Assert.IsTrue(response.status == "error" && response.message == "307. El comprobante contiene un timbre previo.");
+            Assert.IsTrue(response.data.cfdi.Contains("cfdi:Addenda"));
+        }
+
         [TestMethod]
         public void Stamp_Test_45_StampV2XMLV3byToken()
         {
@@ -51,7 +64,22 @@ namespace Test_SW.Services.Stamp_Test
             response = (StampResponseV3)stamp.TimbrarV3(xml);
             Assert.IsTrue(response.status == "error" && response.message == "307. El comprobante contiene un timbre previo.");
         }
-        
+        [TestMethod]
+        public void Stamp_Test_45_StampV2XMLV3WithAddenda307()
+        {
+            var build = new BuildSettings();
+            StampV2 stamp = new StampV2(build.Url, build.Token);
+            var xml = GetXml(build);
+            var response = (StampResponseV3)stamp.TimbrarV3(xml);
+            Assert.IsTrue(response.status == "success"
+               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.cfdi viene vacio.");
+
+            response = (StampResponseV3)stamp.TimbrarV3(xml);
+            Assert.IsTrue(response.status == "error"
+               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.cfdi viene vacio.");
+            Assert.IsTrue(response.data.cfdi.Contains("cfdi:Addenda"));
+
+        }
         [TestMethod]
         public void Stamp_Test_45_StampV2XMLV4byToken()
         {
@@ -72,7 +100,28 @@ namespace Test_SW.Services.Stamp_Test
             response = (StampResponseV4)stamp.TimbrarV4(xml);
             Assert.IsTrue(response.status == "error" && response.message == "307. El comprobante contiene un timbre previo.");
         }
-        
+        [TestMethod]
+        public void Stamp_Test_45_StampV2XMLV4WithAddenda307()
+        {
+            var build = new BuildSettings();
+            StampV2 stamp = new StampV2(build.Url, build.Token);
+            var xml = GetXml(build);
+            var response = (StampResponseV4)stamp.TimbrarV4(xml);
+            Assert.IsTrue(response.data != null, "El resultado data viene vacio.");
+            Assert.IsTrue(!string.IsNullOrEmpty(response.data.cfdi), "El resultado data.cfdi viene vacio.");
+            Assert.IsTrue(!string.IsNullOrEmpty(response.data.cadenaOriginalSAT), "El resultado data.cadenaOriginalSAT viene vacio.");
+            Assert.IsTrue(!string.IsNullOrEmpty(response.data.noCertificadoSAT), "El resultado data.noCertificadoSAT viene vacio.");
+            Assert.IsTrue(!string.IsNullOrEmpty(response.data.noCertificadoCFDI), "El resultado data.noCertificadoCFDI viene vacio.");
+            Assert.IsTrue(!string.IsNullOrEmpty(response.data.uuid), "El resultado data.uuid viene vacio.");
+            Assert.IsTrue(!string.IsNullOrEmpty(response.data.selloSAT), "El resultado data.selloSAT viene vacio.");
+            Assert.IsTrue(!string.IsNullOrEmpty(response.data.selloCFDI), "El resultado data.selloCFDI viene vacio.");
+            Assert.IsTrue(!string.IsNullOrEmpty(response.data.fechaTimbrado), "El resultado data.fechaTimbrado viene vacio.");
+            Assert.IsTrue(!string.IsNullOrEmpty(response.data.qrCode), "El resultado data.qrCode viene vacio.");
+            response = (StampResponseV4)stamp.TimbrarV4(xml);
+            Assert.IsTrue(response.status == "error" && response.message == "307. El comprobante contiene un timbre previo.");
+            Assert.IsTrue(response.data.cfdi.Contains("cfdi:Addenda"));
+
+        }
         [TestMethod]
         public void Stamp_Test_45_ValidateServerError()
         {

--- a/Test_SW-sdk-45/Services/Stamp/Stamp_Test.cs
+++ b/Test_SW-sdk-45/Services/Stamp/Stamp_Test.cs
@@ -118,6 +118,7 @@ namespace Test_SW.Services.Stamp_Test
             Assert.IsTrue(response.status == "success"
                && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.tfd viene vacio.");
         }
+       
         [TestMethod]
         public void Stamp_Test_45_StampXMLV4byToken()
         {

--- a/Test_SW-sdk/Services/Relations/Relations_Test.cs
+++ b/Test_SW-sdk/Services/Relations/Relations_Test.cs
@@ -21,7 +21,7 @@ namespace Test_SW.Services.Relations_Test
         {
             var build = new BuildSettings();
             Relations relations = new Relations(build.Url, build.User, build.Password);
-            RelationsResponse response = relations.RelationsByRfcUuid(build.Rfc, "01724196-ac5a-4735-b621-e3b42bcbb459");
+            RelationsResponse response = relations.RelationsByRfcUuid(build.Rfc, "31c885c8-6dcb-4d82-9cfd-01707c828c50");
             Assert.IsTrue(response.status == "success");
         }
         [TestMethod]
@@ -29,7 +29,7 @@ namespace Test_SW.Services.Relations_Test
         {
             var build = new BuildSettings();
             Relations relations = new Relations(build.Url, build.User, build.Password);
-            RelationsResponse response = relations.RelationsByCSD(build.Cer, build.Key, build.Rfc, build.CerPassword, "01724196-ac5a-4735-b621-e3b42bcbb459");
+            RelationsResponse response = relations.RelationsByCSD(build.Cer, build.Key, build.Rfc, build.CerPassword, "31c885c8-6dcb-4d82-9cfd-01707c828c50");
             Assert.IsTrue(response.status == "success");
         }
         [TestMethod]
@@ -37,7 +37,7 @@ namespace Test_SW.Services.Relations_Test
         {
             var build = new BuildSettings();
             Relations relations = new Relations(build.Url, build.User, build.Password);
-            RelationsResponse response = relations.RelationsByPFX(build.Pfx, build.Rfc, build.CerPassword, "01724196-ac5a-4735-b621-e3b42bcbb459");
+            RelationsResponse response = relations.RelationsByPFX(build.Pfx, build.Rfc, build.CerPassword, "31c885c8-6dcb-4d82-9cfd-01707c828c50");
             Assert.IsTrue(response.status == "success");
         }
         [TestMethod]


### PR DESCRIPTION
Se corrige la libreria para considerar en los metodos StampV2 cuando el xml contiene una addenda e integrarsela al xml de timbrado cuando el error es 307 Timbre duplicado.
Los metodos considerados son: StampV2 - TimbrarV2, TimbrarV3, TimbrarV4.
Estos cambios solo aplican para la libreria dotnet 4.5