### PR TITLE
Métodos para timbrado masivo.

### DIFF
--- a/SW-sdk-45/Properties/AssemblyInfo.cs
+++ b/SW-sdk-45/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.7.2")]
-[assembly: AssemblyFileVersion("0.0.7.2")]
+[assembly: AssemblyVersion("0.0.7.3")]
+[assembly: AssemblyFileVersion("0.0.7.3")]

--- a/SW-sdk-45/Services/Stamp/BaseStamp.cs
+++ b/SW-sdk-45/Services/Stamp/BaseStamp.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
 
 namespace SW.Services.Stamp
 {
@@ -39,6 +41,35 @@ namespace SW.Services.Stamp
                 return handler.HandleException(ex);
             }
         }
+        public virtual ConcurrentBag<StampResponseV1> TimbrarV1(string[] xmls, bool isb64 = false)
+        {
+            StampResponseHandlerV1 handler = new StampResponseHandlerV1();
+            ConcurrentBag<string> request = new ConcurrentBag<string>(xmls);
+            ConcurrentBag<StampResponseV1> response = new ConcurrentBag<StampResponseV1>();
+            try
+            {
+                string format = isb64 ? "b64" : "";
+                Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
+                {
+
+                    var xmlBytes = Encoding.UTF8.GetBytes(i);
+                    var headers = GetHeaders();
+                    var content = GetMultipartContent(xmlBytes);
+                    var proxy = Helpers.RequestHelper.ProxySettings(this.Proxy, this.ProxyPort);
+                    response.Add(handler.GetPostResponse(this.Url,
+                                string.Format("cfdi33/{0}/{1}/{2}",
+                                _operation,
+                                StampTypes.v1.ToString(),
+                                format), headers, content, proxy));
+
+                });
+            }
+            catch (Exception ex)
+            {
+                response.Add(handler.HandleException(ex));
+            }
+            return response;
+        }
         public virtual StampResponseV2 TimbrarV2(string xml, bool isb64 = false)
         {
             StampResponseHandlerV2 handler = new StampResponseHandlerV2();
@@ -59,6 +90,35 @@ namespace SW.Services.Stamp
             {
                 return handler.HandleException(ex);
             }
+        }
+        public virtual ConcurrentBag<StampResponseV2> TimbrarV2(string[] xmls, bool isb64 = false)
+        {
+            StampResponseHandlerV2 handler = new StampResponseHandlerV2();
+            ConcurrentBag<string> request = new ConcurrentBag<string>(xmls);
+            ConcurrentBag<StampResponseV2> response = new ConcurrentBag<StampResponseV2>();
+            try
+            {
+                string format = isb64 ? "b64" : "";
+                Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
+                {
+
+                    var xmlBytes = Encoding.UTF8.GetBytes(i);
+                    var headers = GetHeaders();
+                    var content = GetMultipartContent(xmlBytes);
+                    var proxy = Helpers.RequestHelper.ProxySettings(this.Proxy, this.ProxyPort);
+                    response.Add(handler.GetPostResponse(this.Url,
+                                string.Format("cfdi33/{0}/{1}/{2}",
+                                _operation,
+                                StampTypes.v2.ToString(),
+                                format), headers, content, proxy));
+
+                });
+            }
+            catch (Exception ex)
+            {
+                response.Add(handler.HandleException(ex));
+            }
+            return response;
         }
         public virtual StampResponseV3 TimbrarV3(string xml, bool isb64 = false)
         {
@@ -81,6 +141,35 @@ namespace SW.Services.Stamp
                 return handler.HandleException(ex);
             }
         }
+        public virtual ConcurrentBag<StampResponseV3> TimbrarV3(string[] xmls, bool isb64 = false)
+        {
+            StampResponseHandlerV3 handler = new StampResponseHandlerV3();
+            ConcurrentBag<string> request = new ConcurrentBag<string>(xmls);
+            ConcurrentBag<StampResponseV3> response = new ConcurrentBag<StampResponseV3>();
+            try
+            {
+                string format = isb64 ? "b64" : "";
+                Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
+                {
+
+                    var xmlBytes = Encoding.UTF8.GetBytes(i);
+                    var headers = GetHeaders();
+                    var content = GetMultipartContent(xmlBytes);
+                    var proxy = Helpers.RequestHelper.ProxySettings(this.Proxy, this.ProxyPort);
+                    response.Add(handler.GetPostResponse(this.Url,
+                                string.Format("cfdi33/{0}/{1}/{2}",
+                                _operation,
+                                StampTypes.v3.ToString(),
+                                format), headers, content, proxy));
+
+                });
+            }
+            catch (Exception ex)
+            {
+                response.Add(handler.HandleException(ex));
+            }
+            return response;
+        }
         public virtual StampResponseV4 TimbrarV4(string xml, bool isb64 = false)
         {
             StampResponseHandlerV4 handler = new StampResponseHandlerV4();
@@ -95,12 +184,41 @@ namespace SW.Services.Stamp
                                 string.Format("cfdi33/{0}/{1}/{2}",
                                 _operation,
                                 StampTypes.v4.ToString(),
-                                format), headers, content,proxy);
+                                format), headers, content, proxy);
             }
             catch (Exception ex)
             {
                 return handler.HandleException(ex);
             }
+        }
+        public virtual ConcurrentBag<StampResponseV4> TimbrarV4(string[] xmls, bool isb64 = false)
+        {
+            StampResponseHandlerV4 handler = new StampResponseHandlerV4();
+            ConcurrentBag<string> request = new ConcurrentBag<string>(xmls);
+            ConcurrentBag<StampResponseV4> response = new ConcurrentBag<StampResponseV4>();
+            try
+            {
+                string format = isb64 ? "b64" : "";
+                Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
+                {
+
+                    var xmlBytes = Encoding.UTF8.GetBytes(i);
+                    var headers = GetHeaders();
+                    var content = GetMultipartContent(xmlBytes);
+                    var proxy = Helpers.RequestHelper.ProxySettings(this.Proxy, this.ProxyPort);
+                    response.Add(handler.GetPostResponse(this.Url,
+                                string.Format("cfdi33/{0}/{1}/{2}",
+                                _operation,
+                                StampTypes.v4.ToString(),
+                                format), headers, content, proxy));
+
+                });
+            }
+            catch (Exception ex)
+            {
+                response.Add(handler.HandleException(ex));
+            }
+            return response;
         }
     }
 }

--- a/SW-sdk-45/Services/Stamp/BaseStamp.cs
+++ b/SW-sdk-45/Services/Stamp/BaseStamp.cs
@@ -41,33 +41,34 @@ namespace SW.Services.Stamp
                 return handler.HandleException(ex);
             }
         }
-        public virtual ConcurrentBag<StampResponseV1> TimbrarV1(string[] xmls, bool isb64 = false)
+        public virtual ConcurrentDictionary<string, StampResponseV1> TimbrarV1(string[] xmls, bool isb64 = false)
         {
             StampResponseHandlerV1 handler = new StampResponseHandlerV1();
             ConcurrentBag<string> request = new ConcurrentBag<string>(xmls);
-            ConcurrentBag<StampResponseV1> response = new ConcurrentBag<StampResponseV1>();
-            try
-            {
-                string format = isb64 ? "b64" : "";
-                Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
-                {
+            ConcurrentDictionary<string, StampResponseV1> response = new ConcurrentDictionary<string, StampResponseV1>();
 
+            string format = isb64 ? "b64" : "";
+            Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
+            {
+                try
+                {
                     var xmlBytes = Encoding.UTF8.GetBytes(i);
                     var headers = GetHeaders();
                     var content = GetMultipartContent(xmlBytes);
                     var proxy = Helpers.RequestHelper.ProxySettings(this.Proxy, this.ProxyPort);
-                    response.Add(handler.GetPostResponse(this.Url,
-                                string.Format("cfdi33/{0}/{1}/{2}",
-                                _operation,
-                                StampTypes.v1.ToString(),
-                                format), headers, content, proxy));
+                    response.TryAdd(i, handler.GetPostResponse(this.Url,
+                                    string.Format("cfdi33/{0}/{1}/{2}",
+                                    _operation,
+                                    StampTypes.v1.ToString(),
+                                    format), headers, content, proxy));
 
-                });
-            }
-            catch (Exception ex)
-            {
-                response.Add(handler.HandleException(ex));
-            }
+
+                }
+                catch (Exception ex)
+                {
+                    response.TryAdd(i, handler.HandleException(ex));
+                }
+            });
             return response;
         }
         public virtual StampResponseV2 TimbrarV2(string xml, bool isb64 = false)
@@ -91,33 +92,34 @@ namespace SW.Services.Stamp
                 return handler.HandleException(ex);
             }
         }
-        public virtual ConcurrentBag<StampResponseV2> TimbrarV2(string[] xmls, bool isb64 = false)
+        public virtual ConcurrentDictionary<string, StampResponseV2> TimbrarV2(string[] xmls, bool isb64 = false)
         {
             StampResponseHandlerV2 handler = new StampResponseHandlerV2();
             ConcurrentBag<string> request = new ConcurrentBag<string>(xmls);
-            ConcurrentBag<StampResponseV2> response = new ConcurrentBag<StampResponseV2>();
-            try
-            {
-                string format = isb64 ? "b64" : "";
-                Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
-                {
+            ConcurrentDictionary<string, StampResponseV2> response = new ConcurrentDictionary<string, StampResponseV2>();
 
+            string format = isb64 ? "b64" : "";
+            Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
+            {
+                try
+                {
                     var xmlBytes = Encoding.UTF8.GetBytes(i);
                     var headers = GetHeaders();
                     var content = GetMultipartContent(xmlBytes);
                     var proxy = Helpers.RequestHelper.ProxySettings(this.Proxy, this.ProxyPort);
-                    response.Add(handler.GetPostResponse(this.Url,
-                                string.Format("cfdi33/{0}/{1}/{2}",
-                                _operation,
-                                StampTypes.v2.ToString(),
-                                format), headers, content, proxy));
+                    response.TryAdd(i, handler.GetPostResponse(this.Url,
+                                    string.Format("cfdi33/{0}/{1}/{2}",
+                                    _operation,
+                                    StampTypes.v2.ToString(),
+                                    format), headers, content, proxy));
 
-                });
-            }
-            catch (Exception ex)
-            {
-                response.Add(handler.HandleException(ex));
-            }
+
+                }
+                catch (Exception ex)
+                {
+                    response.TryAdd(i, handler.HandleException(ex));
+                }
+            });
             return response;
         }
         public virtual StampResponseV3 TimbrarV3(string xml, bool isb64 = false)
@@ -141,33 +143,34 @@ namespace SW.Services.Stamp
                 return handler.HandleException(ex);
             }
         }
-        public virtual ConcurrentBag<StampResponseV3> TimbrarV3(string[] xmls, bool isb64 = false)
+        public virtual ConcurrentDictionary<string, StampResponseV3> TimbrarV3(string[] xmls, bool isb64 = false)
         {
             StampResponseHandlerV3 handler = new StampResponseHandlerV3();
             ConcurrentBag<string> request = new ConcurrentBag<string>(xmls);
-            ConcurrentBag<StampResponseV3> response = new ConcurrentBag<StampResponseV3>();
-            try
-            {
-                string format = isb64 ? "b64" : "";
-                Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
-                {
+            ConcurrentDictionary<string, StampResponseV3> response = new ConcurrentDictionary<string, StampResponseV3>();
 
+            string format = isb64 ? "b64" : "";
+            Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
+            {
+                try
+                {
                     var xmlBytes = Encoding.UTF8.GetBytes(i);
                     var headers = GetHeaders();
                     var content = GetMultipartContent(xmlBytes);
                     var proxy = Helpers.RequestHelper.ProxySettings(this.Proxy, this.ProxyPort);
-                    response.Add(handler.GetPostResponse(this.Url,
-                                string.Format("cfdi33/{0}/{1}/{2}",
-                                _operation,
-                                StampTypes.v3.ToString(),
-                                format), headers, content, proxy));
+                    response.TryAdd(i, handler.GetPostResponse(this.Url,
+                                    string.Format("cfdi33/{0}/{1}/{2}",
+                                    _operation,
+                                    StampTypes.v3.ToString(),
+                                    format), headers, content, proxy));
 
-                });
-            }
-            catch (Exception ex)
-            {
-                response.Add(handler.HandleException(ex));
-            }
+
+                }
+                catch (Exception ex)
+                {
+                    response.TryAdd(i, handler.HandleException(ex));
+                }
+            });
             return response;
         }
         public virtual StampResponseV4 TimbrarV4(string xml, bool isb64 = false)
@@ -191,33 +194,34 @@ namespace SW.Services.Stamp
                 return handler.HandleException(ex);
             }
         }
-        public virtual ConcurrentBag<StampResponseV4> TimbrarV4(string[] xmls, bool isb64 = false)
+        public virtual ConcurrentDictionary<string, StampResponseV4> TimbrarV4(string[] xmls, bool isb64 = false)
         {
             StampResponseHandlerV4 handler = new StampResponseHandlerV4();
             ConcurrentBag<string> request = new ConcurrentBag<string>(xmls);
-            ConcurrentBag<StampResponseV4> response = new ConcurrentBag<StampResponseV4>();
-            try
-            {
-                string format = isb64 ? "b64" : "";
-                Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
-                {
+            ConcurrentDictionary<string, StampResponseV4> response = new ConcurrentDictionary<string, StampResponseV4>();
 
+            string format = isb64 ? "b64" : "";
+            Parallel.ForEach(request, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, i =>
+            {
+                try
+                {
                     var xmlBytes = Encoding.UTF8.GetBytes(i);
                     var headers = GetHeaders();
                     var content = GetMultipartContent(xmlBytes);
                     var proxy = Helpers.RequestHelper.ProxySettings(this.Proxy, this.ProxyPort);
-                    response.Add(handler.GetPostResponse(this.Url,
-                                string.Format("cfdi33/{0}/{1}/{2}",
-                                _operation,
-                                StampTypes.v4.ToString(),
-                                format), headers, content, proxy));
+                    response.TryAdd(i, handler.GetPostResponse(this.Url,
+                                    string.Format("cfdi33/{0}/{1}/{2}",
+                                    _operation,
+                                    StampTypes.v4.ToString(),
+                                    format), headers, content, proxy));
 
-                });
-            }
-            catch (Exception ex)
-            {
-                response.Add(handler.HandleException(ex));
-            }
+
+                }
+                catch (Exception ex)
+                {
+                    response.TryAdd(i, handler.HandleException(ex));
+                }
+            });
             return response;
         }
     }

--- a/Test_SW-sdk-45/Services/Stamp/Stamp_Test.cs
+++ b/Test_SW-sdk-45/Services/Stamp/Stamp_Test.cs
@@ -63,7 +63,7 @@ namespace Test_SW.Services.Stamp_Test
             var xml = GetXml(build);
             var response = (StampResponseV2)stamp.TimbrarV2(xml);
             Assert.IsTrue(response.status == "success"
-               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.tfd viene vacio.");
+               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.cfdi viene vacio.");
         }
         [TestMethod]
         public void Stamp_Test_45_StampXMLV2byToken()
@@ -73,7 +73,7 @@ namespace Test_SW.Services.Stamp_Test
             var xml = GetXml(build);
             var response = (StampResponseV2)stamp.TimbrarV2(xml);
             Assert.IsTrue(response.status == "success"
-               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.tfd viene vacio.");
+               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.cfdi viene vacio.");
         }
         [TestMethod]
         public void Stamp_Test_45_StampXMLV2Base64()
@@ -84,7 +84,7 @@ namespace Test_SW.Services.Stamp_Test
             xml = Convert.ToBase64String(Encoding.UTF8.GetBytes(xml));
             var response = (StampResponseV2)stamp.TimbrarV2(xml, true);
             Assert.IsTrue(response.status == "success"
-               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.tfd viene vacio.");
+               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.cfdi viene vacio.");
         }
         [TestMethod]
         public void Stamp_Test_45_StampXMLV2Base64byToken()
@@ -105,7 +105,7 @@ namespace Test_SW.Services.Stamp_Test
             var xml = GetXml(build);
             var response = (StampResponseV3)stamp.TimbrarV3(xml);
             Assert.IsTrue(response.status == "success"
-               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.tfd viene vacio.");
+               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.cfdi viene vacio.");
         }
         [TestMethod]
         public void Stamp_Test_45_StampXMLV3Base64byToken()
@@ -116,7 +116,7 @@ namespace Test_SW.Services.Stamp_Test
             xml = Convert.ToBase64String(Encoding.UTF8.GetBytes(xml));
             var response = (StampResponseV3)stamp.TimbrarV3(xml, true);
             Assert.IsTrue(response.status == "success"
-               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.tfd viene vacio.");
+               && !string.IsNullOrEmpty(response.data.cfdi), "El resultado data.cfdi viene vacio.");
         }
        
         [TestMethod]
@@ -155,6 +155,31 @@ namespace Test_SW.Services.Stamp_Test
             Assert.IsTrue(!string.IsNullOrEmpty(response.data.selloCFDI), "El resultado data.selloCFDI viene vacio.");
             Assert.IsTrue(!string.IsNullOrEmpty(response.data.fechaTimbrado), "El resultado data.fechaTimbrado viene vacio.");
             Assert.IsTrue(!string.IsNullOrEmpty(response.data.qrCode), "El resultado data.qrCode viene vacio.");
+        }
+        [TestMethod]
+        public void Stamp_Test_45_MassStampXMLV4()
+        {
+            var build = new BuildSettings();
+            Stamp stamp = new Stamp(build.Url, build.User, build.Password);
+            List<string> xmls = new List<string>();
+            for (int i = 0; i < 50; i++)
+            {
+                xmls.Add(GetXml(build));
+            }
+            var mass_response = stamp.TimbrarV4(xmls.ToArray());
+            foreach (var response in mass_response)
+            {
+                Assert.IsTrue(response.data != null, "El resultado data viene vacio." + response.message);
+                Assert.IsTrue(!string.IsNullOrEmpty(response.data.cfdi), "El resultado data.cfdi viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(response.data.cadenaOriginalSAT), "El resultado data.cadenaOriginalSAT viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(response.data.noCertificadoSAT), "El resultado data.noCertificadoSAT viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(response.data.noCertificadoCFDI), "El resultado data.noCertificadoCFDI viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(response.data.uuid), "El resultado data.uuid viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(response.data.selloSAT), "El resultado data.selloSAT viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(response.data.selloCFDI), "El resultado data.selloCFDI viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(response.data.fechaTimbrado), "El resultado data.fechaTimbrado viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(response.data.qrCode), "El resultado data.qrCode viene vacio.");
+            }
         }
         [TestMethod]
         public void Stamp_Test_45_ValidateServerError()

--- a/Test_SW-sdk-45/Services/Stamp/Stamp_Test.cs
+++ b/Test_SW-sdk-45/Services/Stamp/Stamp_Test.cs
@@ -167,18 +167,18 @@ namespace Test_SW.Services.Stamp_Test
                 xmls.Add(GetXml(build));
             }
             var mass_response = stamp.TimbrarV4(xmls.ToArray());
-            foreach (var response in mass_response)
+            foreach (var dic in mass_response)
             {
-                Assert.IsTrue(response.data != null, "El resultado data viene vacio." + response.message);
-                Assert.IsTrue(!string.IsNullOrEmpty(response.data.cfdi), "El resultado data.cfdi viene vacio.");
-                Assert.IsTrue(!string.IsNullOrEmpty(response.data.cadenaOriginalSAT), "El resultado data.cadenaOriginalSAT viene vacio.");
-                Assert.IsTrue(!string.IsNullOrEmpty(response.data.noCertificadoSAT), "El resultado data.noCertificadoSAT viene vacio.");
-                Assert.IsTrue(!string.IsNullOrEmpty(response.data.noCertificadoCFDI), "El resultado data.noCertificadoCFDI viene vacio.");
-                Assert.IsTrue(!string.IsNullOrEmpty(response.data.uuid), "El resultado data.uuid viene vacio.");
-                Assert.IsTrue(!string.IsNullOrEmpty(response.data.selloSAT), "El resultado data.selloSAT viene vacio.");
-                Assert.IsTrue(!string.IsNullOrEmpty(response.data.selloCFDI), "El resultado data.selloCFDI viene vacio.");
-                Assert.IsTrue(!string.IsNullOrEmpty(response.data.fechaTimbrado), "El resultado data.fechaTimbrado viene vacio.");
-                Assert.IsTrue(!string.IsNullOrEmpty(response.data.qrCode), "El resultado data.qrCode viene vacio.");
+                Assert.IsTrue(dic.Key != null, "El resultado data viene vacio." + dic.Value.message);
+                Assert.IsTrue(!string.IsNullOrEmpty(dic.Value.data.cfdi), "El resultado data.cfdi viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(dic.Value.data.cadenaOriginalSAT), "El resultado data.cadenaOriginalSAT viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(dic.Value.data.noCertificadoSAT), "El resultado data.noCertificadoSAT viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(dic.Value.data.noCertificadoCFDI), "El resultado data.noCertificadoCFDI viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(dic.Value.data.uuid), "El resultado data.uuid viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(dic.Value.data.selloSAT), "El resultado data.selloSAT viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(dic.Value.data.selloCFDI), "El resultado data.selloCFDI viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(dic.Value.data.fechaTimbrado), "El resultado data.fechaTimbrado viene vacio.");
+                Assert.IsTrue(!string.IsNullOrEmpty(dic.Value.data.qrCode), "El resultado data.qrCode viene vacio.");
             }
         }
         [TestMethod]


### PR DESCRIPTION
Se añaden métodos para timbrado concurrente sin duplicar facturas por medio de varios hilos de ejecución.