### PR TITLE
hotfix44-Net35

### DIFF
--- a/SW-sdk/Services/Stamp/BaseStamp.cs
+++ b/SW-sdk/Services/Stamp/BaseStamp.cs
@@ -7,11 +7,11 @@ namespace SW.Services.Stamp
     public abstract class BaseStamp : StampService
     {
         private string _operation;
-        public BaseStamp(string url, string user, string password, string operation, int proxyPort = 0, string proxy = null) : base(url, user, password, proxy, proxyPort)
+        public BaseStamp(string url, string user, string password, string operation, int proxyPort, string proxy) : base(url, user, password, proxy, proxyPort)
         {
             _operation = operation;
         }
-        public BaseStamp(string url, string token, string operation, int proxyPort = 0, string proxy = null) : base(url, token, proxy, proxyPort)
+        public BaseStamp(string url, string token, string operation, int proxyPort, string proxy) : base(url, token, proxy, proxyPort)
         {
             _operation = operation;
         }

--- a/SW-sdk/Services/Stamp/Stamp.cs
+++ b/SW-sdk/Services/Stamp/Stamp.cs
@@ -6,10 +6,10 @@ namespace SW.Services.Stamp
 {
     public class Stamp : BaseStamp
     {
-        public Stamp(string url, string user, string password) : base(url, user, password, "stamp")
+        public Stamp(string url, string user, string password, int proxyPort = 0, string proxy = null) : base(url, user, password, "stamp", proxyPort, proxy)
         {
         }
-        public Stamp(string url, string token) : base(url, token, "stamp")
+        public Stamp(string url, string token, int proxyPort = 0, string proxy = null) : base(url, token, "stamp", proxyPort, proxy)
         {
         }
     }

--- a/SW-sdk/Services/Stamp/StampService.cs
+++ b/SW-sdk/Services/Stamp/StampService.cs
@@ -17,16 +17,20 @@ namespace SW.Services.Stamp
         internal virtual HttpWebRequest RequestStamping(byte[] xml, string version, string format, string operation)
         {
             this.SetupRequest();
+            HttpWebRequest.DefaultMaximumErrorResponseLength = (1000000 + xml.Length) * 2;
             var request = (HttpWebRequest)WebRequest.Create(this.Url + string.Format("cfdi33/{0}/{1}/{2}", operation, version, format));
+            Helpers.RequestHelper.SetupProxy(this.Proxy, this.ProxyPort, ref request);
+            request.ProtocolVersion = HttpVersion.Version10;
+            request.Timeout = 300000;
+            request.ReadWriteTimeout = 500000;
+            request.KeepAlive = false;
+            request.ServicePoint.Expect100Continue = false;
             request.ContentType = "application/json";
             request.Method = WebRequestMethods.Http.Post;
             request.Headers.Add(HttpRequestHeader.Authorization.ToString(), "bearer " + this.Token);
             request.ContentLength = xml != null ? xml.Length : 0;
             Helpers.RequestHelper.AddFileToRequest(xml, ref request);
-            Helpers.RequestHelper.SetupProxy(this.Proxy, this.ProxyPort, ref request);
             return request;
         }
-
-
     }
 }


### PR DESCRIPTION
**BugFix:** Se corrige la manera en que se realiza la petición HTTP para el objeto HttpWebRequest en framework 3.5 con XML "grandes".

**Issue:** https://github.com/lunasoft/sw-sdk-dotnet/issues/44