### PR TITLE
Se agrega servicio de status para Framework 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1209,6 +1209,52 @@ Taxpayer Taxpayer = new Taxpayer("http://services.test.sw.com.mx", "demo", "1234
     }
 }
 ```
+## Status SW / Consultar el Status de Timbrado o Autenticación ##
+Este método recibe el **Status** actual del servicio consultado.
+***NOTA:*** Se puede hacer una consulta del los siguientes servicios
+SWEnviroment.SandboxAuthentication
+SWEnviroment.Authentication (Productivo)
+SWEnviroment.SandboxStamp
+SWEnviroment.Stamp (Productivo)
+**Ejemplo de consumo de la librería para la utilización**
+```cs
+using SW.Services.StatusSW;
+using System;
+using System.IO;
+using System.Text;
+using SW.Helpers;
+
+namespace ExampleSDK
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            try
+            {
+                //Con token
+                //StatusServiceSW Service = new StatusServiceSW("http://services.test.sw.com.mx", "Token");
+
+                //Con usuario y contraseña
+                StatusServiceSW Service = new StatusServiceSW("http://services.test.sw.com.mx", "User, "Password");
+                //Servicio de Autenticación
+                StatusSWResponse statusService = Service.GetStatusSWServices(SWEnviroment.SandboxAuthentication);
+
+                //Servicio de timbrado
+                //StatusSWResponse statusService = Service.GetStatusSWServices(SWEnviroment.SandboxStamp);
+
+                Console.WriteLine(statusService.data.description);
+                Console.WriteLine(statusService.data.name);
+                Console.WriteLine(statusService.data.status);
+		    }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+            }
+        }
+    }
+}
+```
 Para mayor referencia de un listado completo de los servicios favor de visitar el siguiente [link](http://developers.sw.com.mx/).
 
 Si deseas contribuir a la libreria o tienes dudas envianos un correo a **soporte@sw.com.mx**.

--- a/SW-sdk-45/Helpers/ResponseHelper.cs
+++ b/SW-sdk-45/Helpers/ResponseHelper.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using SW.Services.StatusSW;
 
 namespace SW.Helpers
 {
@@ -181,6 +182,15 @@ namespace SW.Helpers
         internal static TaxpayerResponse ToTaxpayerResponse(this Exception ex)
         {
             return new TaxpayerResponse()
+            {
+                message = ex.Message,
+                status = "error",
+                messageDetail = ex.GetErrorDetail()
+            };
+        }
+        internal static StatusSWResponse ToStatusSWResponse(this Exception ex)
+        {
+            return new StatusSWResponse()
             {
                 message = ex.Message,
                 status = "error",

--- a/SW-sdk-45/Helpers/StatusSWType.cs
+++ b/SW-sdk-45/Helpers/StatusSWType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SW.Helpers
+{ 
+        public enum StatusSWType
+        {
+        stamp,
+        authentication
+    }   
+}

--- a/SW-sdk-45/Properties/AssemblyInfo.cs
+++ b/SW-sdk-45/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.9.0")]
-[assembly: AssemblyFileVersion("0.0.9.0")]
+[assembly: AssemblyVersion("0.0.10.0")]
+[assembly: AssemblyFileVersion("0.0.10.0")]

--- a/SW-sdk-45/SW-sdk-45.csproj
+++ b/SW-sdk-45/SW-sdk-45.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Helpers\RequestHelper.cs" />
     <Compile Include="Helpers\ResponseHelper.cs" />
     <Compile Include="Helpers\ResponseType.cs" />
+    <Compile Include="Helpers\StatusSWType.cs" />
     <Compile Include="Helpers\StreamUtil.cs" />
     <Compile Include="Helpers\Validation.cs" />
     <Compile Include="Helpers\XmlUtils.cs" />
@@ -120,6 +121,11 @@
     <Compile Include="Services\Stamp\StampService.cs" />
     <Compile Include="Helpers\StampTypes.cs" />
     <Compile Include="Services\Stamp\StampValidation.cs" />
+    <Compile Include="Services\StatusSW\StatusServiceSW .cs" />
+    <Compile Include="Services\StatusSW\StatusSWEviroment.cs" />
+    <Compile Include="Services\StatusSW\StatusSWResponse.cs" />
+    <Compile Include="Services\StatusSW\StatusSWResponseHandler.cs" />
+    <Compile Include="Services\StatusSW\StatusSWService.cs" />
     <Compile Include="Services\Status\Status.cs" />
     <Compile Include="Services\Status\StatusService.cs" />
     <Compile Include="Services\Taxpayer\Taxpayer.cs" />

--- a/SW-sdk-45/Services/ResponseHandler.cs
+++ b/SW-sdk-45/Services/ResponseHandler.cs
@@ -102,6 +102,7 @@ namespace SW.Services
             {
                 using (HttpClient client = new HttpClient(proxy))
                 {
+                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
                     foreach (var header in headers)
                     {
                         client.DefaultRequestHeaders.Add(header.Key, header.Value);

--- a/SW-sdk-45/Services/ServicePointManagerCustom.cs
+++ b/SW-sdk-45/Services/ServicePointManagerCustom.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SW.Services
+{
+    class ServicePointManagerCustom
+    {
+    }
+}

--- a/SW-sdk-45/Services/StatusSW/StatusSWEviroment.cs
+++ b/SW-sdk-45/Services/StatusSW/StatusSWEviroment.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SW.Services.StatusSW
+{
+    public enum SWEnviroment
+    {
+        [Description(@"https://status-api-test.sw.com.mx/authentication")] SandboxAuthentication,
+        [Description(@"https://status-api.sw.com.mx/authentication")] Authentication,
+        [Description(@"https://status-api-test.sw.com.mx/stamp")] SandboxStamp,
+        [Description("https://status-api.sw.com.mx/stamp")] Stamp
+    }
+}

--- a/SW-sdk-45/Services/StatusSW/StatusSWResponse.cs
+++ b/SW-sdk-45/Services/StatusSW/StatusSWResponse.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SW.Services.StatusSW
+{
+    public class StatusSWResponse : Entities.Response
+    {
+        [DataMember]
+        public Data data { get; set; }
+        public class Data
+        {
+            [DataMember]
+            public string description { get; set; }
+            [DataMember]
+            public string status { get; set; }
+            [DataMember]
+            public string name { get; set; }
+        }
+    }
+}

--- a/SW-sdk-45/Services/StatusSW/StatusSWResponseHandler.cs
+++ b/SW-sdk-45/Services/StatusSW/StatusSWResponseHandler.cs
@@ -1,0 +1,17 @@
+﻿using SW.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SW.Services.StatusSW
+{
+   internal class StatusSWResponseHandler : ResponseHandler<StatusSWResponse>
+    {
+        public override StatusSWResponse HandleException(Exception ex)
+        {
+            return ex.ToStatusSWResponse();
+        }
+    }
+}

--- a/SW-sdk-45/Services/StatusSW/StatusSWService.cs
+++ b/SW-sdk-45/Services/StatusSW/StatusSWService.cs
@@ -1,0 +1,21 @@
+﻿using SW.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SW.Services.StatusSW 
+{
+   public abstract class StatusSWService : Services
+    {
+
+        protected StatusSWService(string url, string user, string password, string proxy, int proxyPort) : base(url, user, password, proxy, proxyPort)
+        {
+        }
+        protected StatusSWService(string url, string token, string proxy, int proxyPort) : base(url, token, proxy, proxyPort)
+        {
+        }
+        public abstract StatusSWResponse GetStatusSWServices(SWEnviroment urlStatus);      
+    }
+}

--- a/SW-sdk-45/Services/StatusSW/StatusServiceSW .cs
+++ b/SW-sdk-45/Services/StatusSW/StatusServiceSW .cs
@@ -1,0 +1,58 @@
+﻿using SW.Helpers;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SW.Services.StatusSW
+{
+    public class StatusServiceSW : StatusSWService
+    {
+        StatusSWResponseHandler _handler;
+        public StatusServiceSW(string url, string user, string password, int proxyPort = 0, string proxy = null) : base(url, user, password, proxy, proxyPort)
+        {
+            _handler = new StatusSWResponseHandler();
+        }
+        public StatusServiceSW(string url, string token, int proxyPort = 0, string proxy = null) : base(url, token, proxy, proxyPort)
+        {
+            _handler = new StatusSWResponseHandler();
+        }
+        public override StatusSWResponse GetStatusSWServices(SWEnviroment swEnviroment)
+        {
+            return StatusRequest(swEnviroment, StatusSWType.authentication);
+        }
+        internal StatusSWResponse StatusRequest(SWEnviroment swEnviromentRequest, StatusSWType StatusType)
+        {
+            try
+            {
+                new Validation(Url, User, Password, Token).ValidateHeaderParameters();
+                this.SetupRequest();
+                Dictionary<string, string> headers = new Dictionary<string, string>() {
+                    { "Authorization", "bearer " + this.Token }
+                };
+                var proxy = RequestHelper.ProxySettings(this.Proxy, this.ProxyPort);
+                return _handler.GetResponse(GetDescription(swEnviromentRequest), headers, StatusType.ToString(), proxy);
+            }
+            catch (Exception e)
+            {
+                return _handler.HandleException(e);
+            }
+        }
+        internal static string GetDescription(SWEnviroment Enviroment)
+        {
+            FieldInfo oFieldInfo = Enviroment.GetType().GetField(Enviroment.ToString());
+            DescriptionAttribute[] attributes = (DescriptionAttribute[])oFieldInfo.GetCustomAttributes(typeof(DescriptionAttribute), false);
+            if (attributes.Length > 0)
+            {
+                return attributes[0].Description;
+            }
+            else
+            {
+                return Enviroment.ToString();
+            }
+        }
+    }
+}

--- a/Test_SW-sdk-45/Services/StatusSW/StatusSW_test.cs
+++ b/Test_SW-sdk-45/Services/StatusSW/StatusSW_test.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using SW.Services.StatusSW;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Test_SW.Helpers;
+using System.Diagnostics;
+
+namespace Test_SW_sdk_45.Services.StatusSW_test
+{
+    class StatusSW_test
+    {
+        [TestClass]
+        public class StatusSW_Test_45
+        {
+            BuildSettings build = new BuildSettings();
+
+            [TestMethod]
+            public void StatusSW_Test_45_Authentication_User()
+            {
+                StatusServiceSW Service = new StatusServiceSW(build.Url, build.User, build.Password);
+                StatusSWResponse statusService = Service.GetStatusSWServices(SWEnviroment.SandboxAuthentication);
+
+                Debug.WriteLine(statusService.data.description);
+                Debug.WriteLine(statusService.data.name);
+                Debug.WriteLine(statusService.data.status);
+                Assert.IsTrue(statusService.status == "success", statusService.message);
+
+            }
+            [TestMethod]
+            public void StatusSW_Test_45_stamp_User()
+            {
+                StatusServiceSW Service = new StatusServiceSW(build.Url, build.User, build.Password);
+                StatusSWResponse statusService = Service.GetStatusSWServices(SWEnviroment.SandboxStamp);
+
+                Debug.WriteLine(statusService.data.description);
+                Debug.WriteLine(statusService.data.name);
+                Debug.WriteLine(statusService.data.status);
+                Assert.IsTrue(statusService.status == "success", statusService.message);
+            }
+            [TestMethod]
+            public void StatusSW_Test_45_Authentication_token()
+            {
+                StatusServiceSW Service = new StatusServiceSW(build.Url, build.Token);
+                StatusSWResponse statusService = Service.GetStatusSWServices(SWEnviroment.SandboxAuthentication);
+
+                Debug.WriteLine(statusService.data.description);
+                Debug.WriteLine(statusService.data.name);
+                Debug.WriteLine(statusService.data.status);
+                Assert.IsTrue(statusService.status == "success", statusService.message);
+
+            }
+            [TestMethod]
+            public void StatusSW_Test_45_stamp_token()
+            {
+                StatusServiceSW Service = new StatusServiceSW(build.Url, build.Token);
+                StatusSWResponse statusService = Service.GetStatusSWServices(SWEnviroment.SandboxStamp);
+
+                Debug.WriteLine(statusService.data.description);
+                Debug.WriteLine(statusService.data.name);
+                Debug.WriteLine(statusService.data.status);
+                Assert.IsTrue(statusService.status == "success", statusService.message);
+            }
+        }
+    }
+}

--- a/Test_SW-sdk-45/Test_SW-sdk-45.csproj
+++ b/Test_SW-sdk-45/Test_SW-sdk-45.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Services\Stamp\StampV2_Test.cs" />
     <Compile Include="Services\Stamp\Stamp_Test.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\StatusSW\StatusSW_test.cs" />
     <Compile Include="Services\Status\Status_Test.cs" />
     <Compile Include="Services\Taxpayers\Taxplayers_test.cs" />
     <Compile Include="Services\Validate\Validate_UT.cs" />


### PR DESCRIPTION
Se asigna SecurityProtocolType.Tls12 solo en el GET para que sea compatible con la API y no cambiar el Framework 4.5
Los servicios son de tipo Enum para que el usuario no confunda las url, en dado caso que se integre un nuevo endpoint de status solo de agrega en Enum con su descripción